### PR TITLE
Removed pulseaudio linker flags

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,7 +29,7 @@ include_directories(${SBC_INCLUDE_DIRS})
 
 configure_file("${PROJECT_SOURCE_DIR}/config.h.in"  "${PROJECT_SOURCE_DIR}/config.h")
 
-set(MOD_LIBS ${PULSEAUDIO_LIBRARY} pthread pulsecommon-${PulseAudio_VERSION} pulsecore-${PulseAudio_VERSION})
+set(MOD_LIBS ${PULSEAUDIO_LIBRARY} pthread)
 set(CMAKE_INSTALL_RPATH ${CMAKE_INSTALL_PREFIX}/lib/pulseaudio:${CMAKE_INSTALL_PREFIX}/lib/pulse-${PulseAudio_VERSION}/modules)
 
 # libldacBT_enc


### PR DESCRIPTION
I'm getting a number of build errors on debian buster due to these linker flags:

`danny@beast:~/pulseaudio-modules-bt/build$ make
'[ 25%] Built target bluez5-util
[ 50%] Built target ldacBT_enc
[ 56%] Linking C shared module module-bluetooth-discover.so
/usr/bin/ld: cannot find -lpulsecommon-12.2
/usr/bin/ld: cannot find -lpulsecore-12.2
collect2: error: ld returned 1 exit status
make[2]: *** [CMakeFiles/module-bluetooth-discover.dir/build.make:85: module-bluetooth-discover.so] Error 1
make[1]: *** [CMakeFiles/Makefile2:147: CMakeFiles/module-bluetooth-discover.dir/all] Error 2
make: *** [Makefile:130: all] Error 2`

Works fine without them, so I've removed them