### PR TITLE
fix crash when connecting a headset

### DIFF
--- a/src/modules/bluetooth/bluez5-util.c
+++ b/src/modules/bluetooth/bluez5-util.c
@@ -1030,19 +1030,19 @@ static void parse_stream_endpoint_property(pa_bluetooth_stream_endpoint *sep, DB
         case DBUS_TYPE_ARRAY: {
             DBusMessageIter ai;
             uint8_t *config;
-            size_t size;
+            int size = 0;
 
             dbus_message_iter_recurse(&variant_i, &ai);
 
             if (dbus_message_iter_get_arg_type(&ai) == DBUS_TYPE_BYTE && pa_streq(key, "Capabilities")) {
-                dbus_message_iter_get_fixed_array(&ai, &config, (int *) &size);
+                dbus_message_iter_get_fixed_array(&ai, &config, &size);
                 sep->config_size = size;
                 if (size > 0) {
                     sep->config = pa_xnew(uint8_t, size);
                     memcpy(sep->config, config, size);
                 }
 
-                pa_log_debug("%s size:%lu", key, size);
+                pa_log_debug("%s size:%u", key, size);
             }
 
             break;


### PR DESCRIPTION
When connecting bluetooth headphones I was experiencing crashes, see backtrace:
```
#0  __GI_raise (sig=sig@entry=6) at ../sysdeps/unix/sysv/linux/raise.c:50
50      ../sysdeps/unix/sysv/linux/raise.c: No such file or directory.
[Current thread is 1 (Thread 0x7ff5d1fd6840 (LWP 9180))]
(gdb) bt
#0  __GI_raise (sig=sig@entry=6) at ../sysdeps/unix/sysv/linux/raise.c:50
#1  0x00007ff5d2589524 in __GI_abort () at abort.c:79
#2  0x00007ff5d258940f in __assert_fail_base (fmt=0x7ff5d26e4608 "%s%s%s:%u: %s%sAssertion `%s' failed.\n%n", assertion=0x7ff5cd260190 "n < INT_MAX/k", file=0x7ff5cd2606b8 "modules/bluetooth/bluez5-util.c", line=63, function=<optimized out>) at assert.c:92
#3  0x00007ff5d2596722 in __GI___assert_fail (assertion=assertion@entry=0x7ff5cd260190 "n < INT_MAX/k", file=file@entry=0x7ff5cd2606b8 "modules/bluetooth/bluez5-util.c", line=line@entry=63, function=function@entry=0x7ff5cd263210 <__PRETTY_FUNCTION__.3811> "_pa_xnew_internal") at assert.c:101
#4  0x00007ff5cd258054 in _pa_xnew_internal (k=1, n=140690243715076) at /home/asavah/kross/src/pulseaudio-modules-bt/pa/src/pulse/xmalloc.h:63
#5  parse_stream_endpoint_property (i=0x7ffd76692850, sep=0x557296a8c850) at /home/asavah/kross/src/pulseaudio-modules-bt/src/modules/bluetooth/bluez5-util.c:1041
#6  parse_stream_endpoint_properties (i=0x7ffd766927b0, sep=0x557296a8c850) at /home/asavah/kross/src/pulseaudio-modules-bt/src/modules/bluetooth/bluez5-util.c:1065
#7  parse_interfaces_and_properties (y=y@entry=0x557296ae7a60, dict_i=dict_i@entry=0x7ffd76692ab0) at /home/asavah/kross/src/pulseaudio-modules-bt/src/modules/bluetooth/bluez5-util.c:1302
#8  0x00007ff5cd258c4b in filter_cb (bus=<optimized out>, m=0x557296b1b360, userdata=0x557296ae7a60) at /home/asavah/kross/src/pulseaudio-modules-bt/src/modules/bluetooth/bluez5-util.c:1479
#9  0x00007ff5d28278e5 in ?? () from /usr/lib/libdbus-1.so.3
#10 0x00007ff5d28a1124 in dispatch_cb (ea=0x557296a83168, ev=0x557296b08c50, userdata=<optimized out>) at pulsecore/dbus-util.c:53
#11 0x00007ff5d28f42ec in dispatch_defer (m=0x557296a83110) at pulse/mainloop.c:680
#12 pa_mainloop_dispatch (m=m@entry=0x557296a83110) at pulse/mainloop.c:889
#13 0x00007ff5d28f456e in pa_mainloop_iterate (m=0x557296a83110, block=<optimized out>, retval=0x7ffd76692d20) at pulse/mainloop.c:929
#14 0x00007ff5d28f4610 in pa_mainloop_run (m=0x557296a83110, retval=0x7ffd76692d20) at pulse/mainloop.c:945
#15 0x0000557294f074fd in main (argc=<optimized out>, argv=<optimized out>) at daemon/main.c:1144
```

This PR fixes the crash,
dbus_message_iter_get_fixed_array() expects int as it's third argument, not size_t  https://dbus.freedesktop.org/doc/api/html/group__DBusMessage.html#gae195a3312ae445e7ef0196854f3523f8

Runtime tested on a 64-bit system.

Edit: pasted the right backtrace, the former was from badly patched build.