### PR TITLE
Enable AAC afterburner by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ Encoders configurations
 |ldac_abr_t3|\<uint>|threshold for critical TxQueueDepth status|6|
 |aac_bitrate_mode|\[1, 5\]|Variable Bitrate (VBR)|5|
 ||0|Constant Bitrate (CBR)|
-|aac_afterburner (which was "aac_after_buffer" before [359ab0](https://github.com/EHfive/pulseaudio-modules-bt/commit/359ab056e002e53978a1e0b53714d5f2e799c30f)|<on/off>|Enable/Disable AAC encoder afterburner feature|off|
+|aac_afterburner (which was "aac_after_buffer" before [359ab0](https://github.com/EHfive/pulseaudio-modules-bt/commit/359ab056e002e53978a1e0b53714d5f2e799c30f)|<on/off>|Enable/Disable AAC encoder afterburner feature|on (off until [feb9f50](https://github.com/EHfive/pulseaudio-modules-bt/commit/feb9f5072f8cf015d89e38f56a524a930682ce15))|
 |aac_fmt|s16|16-bit signed (little endian)|auto|
 ||s32|32-bit signed|
 ||auto|Ref default-sample-format|

--- a/src/modules/bluetooth/a2dp/a2dp_aac.c
+++ b/src/modules/bluetooth/a2dp/a2dp_aac.c
@@ -91,7 +91,7 @@ pa_aac_encoder_init(pa_a2dp_source_read_cb_t read_cb, pa_a2dp_source_read_buf_fr
     info->read_buf_free = free_cb;
     info->aacenc_handle_opened = false;
     info->aac_enc_bitrate_mode = 5;
-    info->aac_afterburner = false;
+    info->aac_afterburner = true;
     info->force_pa_fmt = PA_SAMPLE_INVALID;
     return true;
 }
@@ -104,7 +104,7 @@ pa_aac_encoder_init(pa_a2dp_source_read_cb_t read_cb, pa_a2dp_source_read_buf_fr
  *                     s32      32-bit signed LE (encoder)
  *                     auto
  *
- * aac_afterburner     <on/off> FDK-AAC afterburner feature (encoder)     off
+ * aac_afterburner     <on/off> FDK-AAC afterburner feature (encoder)     on
  */
 static int pa_aac_update_user_config(pa_proplist *user_config, void **codec_data) {
     aac_info_t *i = *codec_data;


### PR DESCRIPTION
libfdk-aac afterburner feature improves encoded quality at the expense of some increased CPU usage. In practice on modern CPUs the increase in negligible, and the best encoded audio quality is preferable by default.
