### PR TITLE
Docker based release recipe for `ubuntu:eoan` in the repository

### DIFF
--- a/build-scripts/build.bash
+++ b/build-scripts/build.bash
@@ -1,0 +1,27 @@
+#!/bin/bash
+: ${1?"$(printf '%s\n' "Need a parameter! Which distribution would you like to build?" "$( for fn in *.Dockerfile; do printf '> %s\n' "${fn%.Dockerfile}"; done )")"}
+
+ensure_that_has_permissions() {
+    if ! sudo docker version
+    then
+        echo "Most likely you have no permisison to use docker! Aborting!" >&2
+        exit 1
+    fi
+}
+
+main() {
+    local TGT="$1"
+    (
+        set -e
+        sudo docker build -t "tmp.remove.${TGT}" -f "${TGT}.Dockerfile" .
+        sudo docker run --rm --entrypoint /bin/bash "tmp.remove.${TGT}" -c 'tar -cf - /dist' | tar -x --no-same-owner
+        echo "This script will not clean-up itself Docker Images!" >&2
+    )
+}
+
+if [[ $EUID -eq 0 ]]; then
+   echo "Script sould be run as a user! Not root!" >&2
+   exit 1
+fi
+ensure_that_has_permissions
+main "$@"

--- a/build-scripts/ubuntu-eoan.Dockerfile
+++ b/build-scripts/ubuntu-eoan.Dockerfile
@@ -1,0 +1,42 @@
+FROM ubuntu:eoan
+
+RUN apt update && apt install -y build-essential cmake pkg-config libtool cmake git checkinstall
+RUN mkdir -p /dist
+
+RUN git clone https://github.com/EHfive/ldacBT.git \
+    && cd ldacBT \
+    && git submodule update --init \
+    && mkdir build && cd build \
+    && cmake     -DCMAKE_INSTALL_PREFIX=/usr     -DINSTALL_LIBDIR=/usr/lib      \-DLDAC_SOFT_FLOAT=OFF     ../ \
+    && echo 'Homepage: https://github.com/EHfive/ldacBT' > description-pak \
+    && checkinstall -y  --install=yes \
+        --pkgname=libldac-dev \
+        --pkgrelease='eoan' \
+        --pkgarch=$(dpkg --print-architecture) \
+        --pkglicense='' \
+        --provides='libldac,libldac-dev' \
+    && cp *.deb /dist \
+    && cd ..
+
+RUN apt install -y libsbc-dev libavcodec-dev libavutil-dev libfdk-aac-dev \
+        libdbus-1-dev libbluetooth-dev libpulse-dev pulseaudio \
+    && git clone https://github.com/EHfive/pulseaudio-modules-bt.git \
+    && cd pulseaudio-modules-bt \
+    && git submodule update --init \
+    && git -C pa/ checkout v`pkg-config libpulse --modversion|sed 's/[^0-9.]*\([0-9.]*\).*/\1/'` \
+    && mkdir build && cd build \
+    && cmake .. \
+    && echo 'Homepage: https://github.com/EHfive/pulseaudio-modules-bt' > description-pak \
+    && checkinstall -y --install=no \
+        --pkgname=pulseaudio-modules-bt \
+        --pkgrelease='eoan' \
+        --pkgarch=$(dpkg --print-architecture) \
+        --pkglicense='GPLv3' \
+        --requires='libfdk-aac1,libsbc1, libdbus-1-3,bluez,libpulse0,pulseaudio' \
+        --suggest='libavcodec,libldac' \
+        --replaces='pulseaudio-module-bluetooth' \
+        --conflicts='pulseaudio-module-bluetooth' \
+        --provides='pulseaudio-module-bluetooth' \
+    && cp *.deb /dist
+
+RUN ls -l /dist


### PR DESCRIPTION
Hello.

I am pretty sure this script this does not meet all `Debian/Ubuntu` packaging guide/quality, but I would like to share with you what I have typed for myself during my spare time.

Also I would like to emphasize that `build.bash` script is intended to be somehow generic.

## Usage after getting files

1. Run packages building within Docker

```shell
cd build-scripts
./build.bash ubuntu-eoan
```

2. Expect new `./dist` directory with packages.
3. [Optional] Remove `tmp.remove.*` Docker Image(s) or if you are know what are you doing do `sudo docker system prune`.

## Concept to add new kind of releases

1. Create own `Dockerfile` recipe and name it:
 
>  *\<release-name\>*`.`*Dockerfile*

2. Ensure that your recipe finally would place packages inside Docker Image in `/dist` directory
3. `build.bash` will take care of anything else, *but not cleaning-up Docker Image as it is barely possible when Image has many layers and if it would be used in some automated build system, so deleting layers also means loosing "cache"*.

I am opened for propositions to handle that pull request till the end - or maybe make it separate project. But I am awaiting for some discussion.

I have also on my mind that it can be turned into `Travis` for binary releases automation, but I have never worked with `Travis` before, nor with GitHub releasing API.
It is also possible to develop automatic releases based on quite new `GitHub Workflow` under `Actions` tab.

I am a kind of `GitLab Runner` type, so I believe I would quickly catch it.